### PR TITLE
Fix missing shadow uniforms for world chunks

### DIFF
--- a/Objects/ChunkObject.cpp
+++ b/Objects/ChunkObject.cpp
@@ -142,7 +142,14 @@ void ChunkObject::draw(Camera &camera, std::shared_ptr<ShadowMap> shadow_map) co
   texture_atlas->bind(0);
   shader->setInt("atlas", 0);
 
-  shadow_map->bind(1);
+  if (shadow_map) {
+    shader->setMat4("lightSpaceMatrix", shadow_map->LastLightSpace());
+    shader->setVec3("lightPos", shadow_map->LastLightPosition());
+    shadow_map->bind(1);
+  } else {
+    shader->setMat4("lightSpaceMatrix", glm::mat4(1.0f));
+    shader->setVec3("lightPos", glm::vec3(0.0f));
+  }
   shader->setInt("shadowMap", 1);
 
   mesh->draw();

--- a/Objects/ShadowMap.cpp
+++ b/Objects/ShadowMap.cpp
@@ -3,6 +3,8 @@
 //
 #include "ShadowMap.h"
 
+#include <cmath>
+
 ShadowMap::ShadowMap(std::shared_ptr<Shader>& depthShader, int res)
     : resolution(res), shader(depthShader) {
     Init(resolution);
@@ -27,6 +29,7 @@ void ShadowMap::Init(int res) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
     float borderColor[] = {1.0f, 1.0f, 1.0f, 1.0f};
     glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColor);
 
@@ -49,7 +52,7 @@ void ShadowMap::Resize(int newRes) {
     Init(newRes);
 }
 
-glm::mat4 ShadowMap::GetLightSpaceMatrix(const glm::vec3& sunDir, const glm::vec3& center) const {
+glm::mat4 ShadowMap::GetLightSpaceMatrix(const glm::vec3& sunDir, const glm::vec3& center) {
     float near_plane = 1.0f, far_plane = 300.0f;
     float orthoSize = 100.0f; // cover your scene
 
@@ -57,8 +60,16 @@ glm::mat4 ShadowMap::GetLightSpaceMatrix(const glm::vec3& sunDir, const glm::vec
                                            -orthoSize, orthoSize,
                                            near_plane, far_plane);
 
-    glm::vec3 lightPos = center - sunDir * 100.0f; // place light opposite the sunDir
-    glm::mat4 lightView = glm::lookAt(lightPos, center, glm::vec3(0.0f, 1.0f, 0.0f));
+    glm::vec3 dir = glm::length(sunDir) > 0.0001f ? glm::normalize(sunDir)
+                                                  : glm::vec3(0.0f, -1.0f, 0.0f);
+    float lightDistance = 100.0f;
+    lastLightPos_ = center - dir * lightDistance; // place light opposite the sunDir
+
+    glm::vec3 up = std::abs(glm::dot(dir, glm::vec3(0.0f, 1.0f, 0.0f))) > 0.99f
+                        ? glm::vec3(0.0f, 0.0f, 1.0f)
+                        : glm::vec3(0.0f, 1.0f, 0.0f);
+
+    glm::mat4 lightView = glm::lookAt(lastLightPos_, center, up);
 
     return lightProjection * lightView;
 }

--- a/Objects/ShadowMap.h
+++ b/Objects/ShadowMap.h
@@ -25,9 +25,10 @@ public:
 
   GLuint GetDepthMap() const { return depthMap; }
   glm::mat4 GetLightSpaceMatrix(const glm::vec3& sunDir,
-                                         const glm::vec3& center) const;
+                                         const glm::vec3& center);
 
   const glm::mat4& LastLightSpace() const { return lastLightSpace_; }
+  const glm::vec3& LastLightPosition() const { return lastLightPos_; }
 
   // Camera GetLightCamera(const glm::vec3& sunDir) const;
 
@@ -39,6 +40,7 @@ private:
   int resolution;
 
   glm::mat4 lastLightSpace_{1.0f};
+  glm::vec3 lastLightPos_{0.0f};
 
   std::shared_ptr<Shader>& shader;
 

--- a/WorldRenderer.cpp
+++ b/WorldRenderer.cpp
@@ -57,7 +57,7 @@ void WorldRenderer::draw_depth_only(
     if (!chunk->mesh->vao) continue;
 
     glm::mat4 model = glm::mat4(1.0f);
-    model = glm::translate(model, glm::vec3(chunk->position.x, 0, chunk->position.z));
+    model = glm::translate(model, chunk->chunk_pos);
     depthShader->setMat4("model", model);
 
     chunk->mesh->draw();
@@ -90,13 +90,18 @@ void WorldRenderer::tick(glm::vec3 player_location, int render_distance) {
   //   }
   // }
 
+  const float max_chunk_distance = static_cast<float>(render_distance * CHUNK_SIZE);
+
   visibleChunks.erase(
       std::remove_if(
           visibleChunks.begin(), visibleChunks.end(),
           [&](const std::shared_ptr<ChunkObject>& chunk) {
               if (!chunk) return true; // remove null chunks
-              float distance = glm::distance(chunk->chunk_pos, player_location);
-              return distance >= render_distance;
+
+              // Compare using world-space distances – chunk_pos is expressed in world units,
+              // so we also work in world units here.
+              const float distance = glm::distance(chunk->chunk_pos, player_location);
+              return distance >= max_chunk_distance;
           }),
       visibleChunks.end()
   );
@@ -110,7 +115,7 @@ void WorldRenderer::tick(glm::vec3 player_location, int render_distance) {
 
     float distance = glm::distance(colCenter, player_location);
 
-    if (distance >= render_distance * CHUNK_SIZE) {
+    if (distance >= max_chunk_distance) {
       it = world.chunkColumns.erase(it);
     } else {
       ++it;


### PR DESCRIPTION
## Summary
- send the shadow map lightSpaceMatrix and light position to the chunk shader when drawing so the mesh shader can sample the depth texture correctly
- keep track of the directional light position when building the light-space matrix and clamp the depth texture along both axes to stabilize shadow sampling

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc020790dc832d8cfeb436b7295589