### PR TITLE
Use integer world positions for blocks

### DIFF
--- a/Block.h
+++ b/Block.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <glm/ext/scalar_uint_sized.hpp>
+#include <glm/vec3.hpp>
 
 #include "Objects/GameObject.h"
 
@@ -12,12 +13,13 @@ enum class BlockID : glm::uint8 {
 class Block {
 public:
   BlockID id = BlockID::Air;
-  glm::vec3 position = glm::vec3(0, 0, 0);
+  glm::ivec3 position {0, 0, 0};
 
-  AABB getAABB() {
+  [[nodiscard]] AABB getAABB() const {
+    glm::vec3 min = glm::vec3(position);
     return AABB(
-      position,
-      glm::vec3(1,1,1));
+      min,
+      min + glm::vec3(1.0f));
   }
   // ...
 

--- a/Chunk.cpp
+++ b/Chunk.cpp
@@ -37,7 +37,7 @@ Chunk::Chunk(int chunkX, int chunkY, int chunkZ, int seed) {
   //   }
   // }
 
-  position = glm::vec3(chunkX, chunkY, chunkZ);
+  position = glm::ivec3(chunkX, chunkY, chunkZ);
 
   // Setup noise generator
   FastNoiseLite noise;
@@ -70,7 +70,10 @@ Chunk::Chunk(int chunkX, int chunkY, int chunkZ, int seed) {
           blocks[x][y][z] = Block{ BlockID::Air };
         }
 
-        blocks[x][y][z].position = glm::vec3(x, y, z);
+        blocks[x][y][z].position = glm::ivec3(
+          chunkX * CHUNK_SIZE + x,
+          chunkY * CHUNK_SIZE + y,
+          chunkZ * CHUNK_SIZE + z);
       }
     }
   }

--- a/Chunk.h
+++ b/Chunk.h
@@ -13,7 +13,7 @@ static inline constexpr int CHUNK_SIZE = 16;
 class Chunk {
 public:
 
-  glm::vec3 position;
+  glm::ivec3 position;
 
   Block blocks[CHUNK_SIZE][CHUNK_SIZE][CHUNK_SIZE];
 


### PR DESCRIPTION
## Summary
- store chunk indices using integer vectors and populate each block with its world-space integer coordinates
- derive block axis-aligned bounding boxes from their integer world positions to improve spatial accuracy

## Testing
- cmake --build build *(fails: build cache points to /home/code/CLionProjects/LearningOpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68dc198af890832dabfa5f1036fc2213