### PR TITLE
Fix chunk rebuild queue ownership

### DIFF
--- a/World.cpp
+++ b/World.cpp
@@ -35,6 +35,31 @@ Chunk* World::getChunkPtrAt(int x, int y, int z) {
 }
 
 
+Chunk* World::tryGetChunkPtrAt(int x, int y, int z) {
+  int chunk_y = floorDiv(y, CHUNK_SIZE);
+  if (chunk_y < 0 || chunk_y >= WORLD_HEIGHT_CHUNKS) {
+    return nullptr;
+  }
+
+  int chunk_x = floorDiv(x, CHUNK_SIZE);
+  int chunk_z = floorDiv(z, CHUNK_SIZE);
+
+  ChunkCoord coord{chunk_x, chunk_z};
+  auto column_it = chunkColumns.find(coord);
+  if (column_it == chunkColumns.end()) {
+    return nullptr;
+  }
+
+  ChunkColumn& column = column_it->second;
+  const auto& chunk_ptr = column.chunks[chunk_y];
+  if (!chunk_ptr) {
+    return nullptr;
+  }
+
+  return chunk_ptr.get();
+}
+
+
 Block& World::getBlockAt(int x, int y, int z) {
   if (y < 0 || y >= WORLD_HEIGHT_CHUNKS * CHUNK_SIZE) {
     static Block air(BlockID::Air, {0,0,0});
@@ -49,6 +74,24 @@ Block& World::getBlockAt(int x, int y, int z) {
   int local_z = floorMod(z, CHUNK_SIZE);
 
   return chunk.blocks[local_x][local_y][local_z];
+}
+
+
+Block* World::tryGetBlockAt(int x, int y, int z) {
+  if (y < 0 || y >= WORLD_HEIGHT_CHUNKS * CHUNK_SIZE) {
+    return nullptr;
+  }
+
+  Chunk* chunk = tryGetChunkPtrAt(x, y, z);
+  if (!chunk) {
+    return nullptr;
+  }
+
+  int local_x = floorMod(x, CHUNK_SIZE);
+  int local_y = floorMod(y, CHUNK_SIZE);
+  int local_z = floorMod(z, CHUNK_SIZE);
+
+  return &chunk->blocks[local_x][local_y][local_z];
 }
 
 
@@ -261,6 +304,11 @@ std::vector<std::reference_wrapper<Block>> World::getNearbyBlocks(glm::vec3 vec)
 }
 
 bool World::isAir(int x, int y, int z) {
-  return getBlockAt(x, y, z).isAir();
+  Block* block = tryGetBlockAt(x, y, z);
+  if (!block) {
+    return true;
+  }
+
+  return block->isAir();
 }
 

--- a/World.h
+++ b/World.h
@@ -77,9 +77,11 @@ public:
 
   Chunk& getChunkAt(int x, int y, int z);
   Chunk* getChunkPtrAt(int x, int y, int z);
+  Chunk* tryGetChunkPtrAt(int x, int y, int z);
 
 
   Block& getBlockAt(int x, int y, int z);
+  Block* tryGetBlockAt(int x, int y, int z);
   void setBlockAt(int x, int y, int z, Block block);
 
   ChunkColumn &getOrCreateColumn(int cx, int cz);

--- a/WorldRenderer.cpp
+++ b/WorldRenderer.cpp
@@ -12,24 +12,40 @@ WorldRenderer::WorldRenderer(
   World &world)
   : shader(shaderPtr), texture_atlas(ta), world(world) {}
 
+void WorldRenderer::rebuildChunkMesh(Camera &cam, Chunk *chunk) {
+  (void)cam;
+  if (chunk == nullptr) {
+    return;
+  }
+
+  auto chunkObj = std::make_shared<ChunkObject>(shader, texture_atlas);
+  chunkObj->setChunk(chunk);
+
+  chunkObj->chunk_pos = {
+    chunk->position.x * CHUNK_SIZE,
+    chunk->position.y * CHUNK_SIZE,
+    chunk->position.z * CHUNK_SIZE
+  };
+
+  chunkObj->rebuildMesh(world);
+  visibleChunks.push_back(std::move(chunkObj));
+}
+
 void WorldRenderer::rebuildTheseChunks(
   Camera &cam,
-  std::vector<std::shared_ptr<Chunk>> chunks) {
+  const std::vector<std::shared_ptr<Chunk>> &chunks) {
 
-  for (auto& chunk : chunks) {
-    auto chunkObj = std::make_shared<ChunkObject>(shader, texture_atlas);
-    chunkObj->setChunk(chunk.get());
+  for (const auto& chunk : chunks) {
+    rebuildChunkMesh(cam, chunk.get());
+  }
+}
 
+void WorldRenderer::rebuildTheseChunks(
+  Camera &cam,
+  const std::vector<Chunk *> &chunks) {
 
-    chunkObj->chunk_pos = {
-      chunk->position.x * CHUNK_SIZE,
-      chunk->position.y * CHUNK_SIZE,
-      chunk->position.z * CHUNK_SIZE
-    };
-
-
-    chunkObj->rebuildMesh(world);
-    visibleChunks.push_back(chunkObj);
+  for (auto* chunk : chunks) {
+    rebuildChunkMesh(cam, chunk);
   }
 }
 

--- a/WorldRenderer.h
+++ b/WorldRenderer.h
@@ -26,7 +26,7 @@ public:
   std::shared_ptr<Shader> &shader;
   std::vector<std::shared_ptr<ChunkObject>> visibleChunks;
 
-  std::vector<std::shared_ptr<Chunk>> chunksToRebuild;
+  std::vector<Chunk*> chunksToRebuild;
 
   std::shared_ptr<Texture>& texture_atlas;
   World &world;
@@ -41,13 +41,20 @@ public:
 
   void rebuildTheseChunks(
     Camera& cam,
-    std::vector<std::shared_ptr<Chunk>> chunks);
+    const std::vector<std::shared_ptr<Chunk>>& chunks);
+
+  void rebuildTheseChunks(
+    Camera& cam,
+    const std::vector<Chunk*>& chunks);
 
   void draw(Camera& cam, std::shared_ptr<ShadowMap> shadow_map);
 
   void draw_depth_only(const glm::mat4& lightSpaceMatrix, const std::shared_ptr<Shader>& depthShader);
 
   void tick(glm::vec3 player_location, int render_distance);
+
+private:
+  void rebuildChunkMesh(Camera& cam, Chunk* chunk);
 };
 
 


### PR DESCRIPTION
## Summary
- avoid creating temporary shared owners when queuing chunk rebuilds to prevent double frees
- centralize chunk mesh rebuild logic so it can accept both shared and raw chunk pointers

## Testing
- cmake --build build *(fails: cache points to /home/code/CLionProjects/LearningOpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe2dfe9bc832d9015a410ca1c2f50