### PR TITLE
Fix invisible neighbor blocks after block edits

### DIFF
--- a/World.cpp
+++ b/World.cpp
@@ -6,10 +6,15 @@
 
 #include <cfloat>
 #include <glm/common.hpp>
+#include <iterator>
 // #include <glm/detail/func_geometric.inl>
 
 Chunk & World::getChunkAt(int x, int y, int z) {
   return *getChunkPtrAt(x, y, z);
+}
+
+std::shared_ptr<Chunk> World::makeChunk(int chunk_x, int chunk_y, int chunk_z) {
+  return std::make_shared<Chunk>(chunk_x, chunk_y, chunk_z, seed);
 }
 
 Chunk* World::getChunkPtrAt(int x, int y, int z) {
@@ -21,7 +26,9 @@ Chunk* World::getChunkPtrAt(int x, int y, int z) {
   ChunkColumn& column = chunkColumns[coord];
 
   if (!column.chunks[chunk_y]) {
-    column.chunks[chunk_y] = std::make_unique<Chunk>(chunk_x, chunk_y, chunk_z, seed);
+    auto new_chunk = makeChunk(chunk_x, chunk_y, chunk_z);
+    column.chunks[chunk_y] = new_chunk;
+    pendingChunks.emplace_back(std::move(new_chunk));
   }
 
   return column.chunks[chunk_y].get();
@@ -104,6 +111,16 @@ ChunkColumn& World::getOrCreateColumn(int cx, int cz) {
 std::vector<std::shared_ptr<Chunk>> World::ensureChunkAndNeighbors(
   int worldX, int worldY, int worldZ, int radius) {
 
+  std::vector<std::shared_ptr<Chunk>> new_chunks;
+
+  if (!pendingChunks.empty()) {
+    new_chunks.insert(
+      new_chunks.end(),
+      std::make_move_iterator(pendingChunks.begin()),
+      std::make_move_iterator(pendingChunks.end()));
+    pendingChunks.clear();
+  }
+
   int cx = floorDiv(worldX, CHUNK_SIZE);
   int cz = floorDiv(worldZ, CHUNK_SIZE);
 
@@ -119,8 +136,6 @@ std::vector<std::shared_ptr<Chunk>> World::ensureChunkAndNeighbors(
   }
 
   // bool should_update = false;
-  std::vector<std::shared_ptr<Chunk>> new_chunks;
-
   for (int dx = -radius; dx <= radius; ++dx) {
     for (int dz = -radius; dz <= radius; ++dz) {
       // if (dx*dx + dz*dz > radius*radius) continue;
@@ -143,8 +158,9 @@ std::vector<std::shared_ptr<Chunk>> World::ensureChunkAndNeighbors(
 
       for (int ncy = 0; ncy < WORLD_HEIGHT_CHUNKS; ++ncy) {
         if (!col.chunks[ncy]) {
-          col.chunks[ncy] = std::make_shared<Chunk>(ncx, ncy, ncz, seed);
-          new_chunks.emplace_back(col.chunks[ncy]);
+          auto chunk = makeChunk(ncx, ncy, ncz);
+          col.chunks[ncy] = chunk;
+          new_chunks.emplace_back(std::move(chunk));
         }
       }
     }

--- a/World.h
+++ b/World.h
@@ -63,6 +63,9 @@ inline int floorMod(int a, int b) {
 class World {
 private:
   int seed = 0;
+  std::vector<std::shared_ptr<Chunk>> pendingChunks;
+
+  std::shared_ptr<Chunk> makeChunk(int chunk_x, int chunk_y, int chunk_z);
 
 public:
   std::unordered_map<ChunkCoord, ChunkColumn, ChunkCoordHash> chunkColumns;

--- a/WorldRenderer.cpp
+++ b/WorldRenderer.cpp
@@ -14,22 +14,35 @@ WorldRenderer::WorldRenderer(
 
 void WorldRenderer::rebuildTheseChunks(
   Camera &cam,
-  std::vector<std::shared_ptr<Chunk>> chunks) {
+  const std::vector<std::shared_ptr<Chunk>>& chunks) {
 
-  for (auto& chunk : chunks) {
-    auto chunkObj = std::make_shared<ChunkObject>(shader, texture_atlas);
-    chunkObj->setChunk(chunk.get());
+  for (const auto& chunk : chunks) {
+    if (!chunk) continue;
 
-
-    chunkObj->chunk_pos = {
+    auto chunkPos = glm::vec3(
       chunk->position.x * CHUNK_SIZE,
       chunk->position.y * CHUNK_SIZE,
-      chunk->position.z * CHUNK_SIZE
-    };
+      chunk->position.z * CHUNK_SIZE);
 
+    auto existing = std::find_if(
+      visibleChunks.begin(),
+      visibleChunks.end(),
+      [&](const std::shared_ptr<ChunkObject>& obj) {
+        return obj && obj->chunk == chunk.get();
+      });
 
-    chunkObj->rebuildMesh(world);
-    visibleChunks.push_back(chunkObj);
+    if (existing == visibleChunks.end()) {
+      auto chunkObj = std::make_shared<ChunkObject>(shader, texture_atlas);
+      chunkObj->setChunk(chunk.get());
+      chunkObj->chunk_pos = chunkPos;
+      chunkObj->rebuildMesh(world);
+      visibleChunks.push_back(chunkObj);
+    } else {
+      auto& chunkObj = *existing;
+      chunkObj->setChunk(chunk.get());
+      chunkObj->chunk_pos = chunkPos;
+      chunkObj->rebuildMesh(world);
+    }
   }
 }
 

--- a/WorldRenderer.h
+++ b/WorldRenderer.h
@@ -41,7 +41,7 @@ public:
 
   void rebuildTheseChunks(
     Camera& cam,
-    std::vector<std::shared_ptr<Chunk>> chunks);
+    const std::vector<std::shared_ptr<Chunk>>& chunks);
 
   void draw(Camera& cam, std::shared_ptr<ShadowMap> shadow_map);
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include "Mesh.h"
 #include "Objects/MeshObject.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -588,11 +589,60 @@ void set_block(glm::ivec3 pos, BlockID new_block) {
         block
     );
 
-    if (auto chunkPtr = world.getChunkPtrAt(x, y, z)) {
-        // rebuild chunk next frame
-        // printf("0x%x\n", chunkPtr.get());
-        world_renderer->chunksToRebuild
-            .emplace_back(chunkPtr);
+    const int chunk_x = floorDiv(x, CHUNK_SIZE);
+    const int chunk_y = floorDiv(y, CHUNK_SIZE);
+    const int chunk_z = floorDiv(z, CHUNK_SIZE);
+
+    const auto queue_chunk = [&](int cx, int cy, int cz) {
+        if (cy < 0 || cy >= WORLD_HEIGHT_CHUNKS) {
+            return;
+        }
+
+        ChunkCoord coord{cx, cz};
+        auto column_it = world.chunkColumns.find(coord);
+        if (column_it == world.chunkColumns.end()) {
+            return;
+        }
+
+        const auto &chunkPtr = column_it->second.chunks[cy];
+        if (!chunkPtr) {
+            return;
+        }
+
+        const bool alreadyQueued = std::any_of(
+            world_renderer->chunksToRebuild.begin(),
+            world_renderer->chunksToRebuild.end(),
+            [&](const std::shared_ptr<Chunk>& queued) {
+                return queued.get() == chunkPtr.get();
+            });
+
+        if (!alreadyQueued) {
+            world_renderer->chunksToRebuild.emplace_back(chunkPtr);
+        }
+    };
+
+    const int local_x = floorMod(x, CHUNK_SIZE);
+    const int local_y = floorMod(y, CHUNK_SIZE);
+    const int local_z = floorMod(z, CHUNK_SIZE);
+
+    queue_chunk(chunk_x, chunk_y, chunk_z);
+
+    if (local_x == 0) {
+        queue_chunk(chunk_x - 1, chunk_y, chunk_z);
+    } else if (local_x == CHUNK_SIZE - 1) {
+        queue_chunk(chunk_x + 1, chunk_y, chunk_z);
+    }
+
+    if (local_y == 0) {
+        queue_chunk(chunk_x, chunk_y - 1, chunk_z);
+    } else if (local_y == CHUNK_SIZE - 1) {
+        queue_chunk(chunk_x, chunk_y + 1, chunk_z);
+    }
+
+    if (local_z == 0) {
+        queue_chunk(chunk_x, chunk_y, chunk_z - 1);
+    } else if (local_z == CHUNK_SIZE - 1) {
+        queue_chunk(chunk_x, chunk_y, chunk_z + 1);
     }
 }
 


### PR DESCRIPTION
## Summary
- queue the edited chunk and any neighboring chunks on chunk boundaries for rebuilds so physics and raycasts match the rendered mesh

## Testing
- not run (OpenGL project; container lacks required runtime dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68dfdaba2878832d88edbb9e59d076f8