### PR TITLE
Fix raycast, collisions, and chunk mesh updates

### DIFF
--- a/Objects/ChunkObject.cpp
+++ b/Objects/ChunkObject.cpp
@@ -8,7 +8,7 @@
 
 ChunkObject::ChunkObject(std::shared_ptr<Shader>& s,
     std::shared_ptr<Texture>& ta):
-  shader(s), texture_atlas(ta) {}
+  shader(s), texture_atlas(ta), chunk(nullptr) {}
 
 
 

--- a/World.cpp
+++ b/World.cpp
@@ -5,8 +5,11 @@
 #include "World.h"
 
 #include <cfloat>
-#include <glm/common.hpp>
+#include <cmath>
 #include <iterator>
+#include <limits>
+#include <glm/common.hpp>
+#include <glm/geometric.hpp>
 // #include <glm/detail/func_geometric.inl>
 
 Chunk & World::getChunkAt(int x, int y, int z) {
@@ -217,25 +220,26 @@ std::optional<RaycastHit> World::raycastBlock(
   const glm::vec3 &direction,
   float maxDistance)
 {
+  if (glm::length(direction) <= std::numeric_limits<float>::epsilon()) {
+    return std::nullopt;
+  }
+
   glm::ivec3 voxel = glm::floor(origin);
 
   glm::ivec3 step(
-      direction.x > 0 ? 1 : -1,
-      direction.y > 0 ? 1 : -1,
-      direction.z > 0 ? 1 : -1
+      direction.x > 0 ? 1 : (direction.x < 0 ? -1 : 0),
+      direction.y > 0 ? 1 : (direction.y < 0 ? -1 : 0),
+      direction.z > 0 ? 1 : (direction.z < 0 ? -1 : 0)
   );
 
-  glm::vec3 tMax;
-  glm::vec3 tDelta;
+  glm::vec3 tMax(FLT_MAX);
+  glm::vec3 tDelta(FLT_MAX);
 
   for (int i = 0; i < 3; i++) {
-    if (direction[i] != 0) {
-      float voxelBorder = (step[i] > 0 ? (voxel[i] + 1.0f) : voxel[i]);
+    if (step[i] != 0) {
+      float voxelBorder = voxel[i] + (step[i] > 0 ? 1.0f : 0.0f);
       tMax[i] = (voxelBorder - origin[i]) / direction[i];
-      tDelta[i] = step[i] / direction[i];
-    } else {
-      tMax[i] = FLT_MAX;
-      tDelta[i] = FLT_MAX;
+      tDelta[i] = std::abs(1.0f / direction[i]);
     }
   }
 
@@ -248,32 +252,20 @@ std::optional<RaycastHit> World::raycastBlock(
       return RaycastHit{voxel, hitNormal};
     }
 
-    // Step to next voxel
-    if (tMax.x < tMax.y) {
-      if (tMax.x < tMax.z) {
-        voxel.x += step.x;
-        dist = tMax.x;
-        tMax.x += tDelta.x;
-        hitNormal = glm::ivec3(-step.x, 0, 0);
-      } else {
-        voxel.z += step.z;
-        dist = tMax.z;
-        tMax.z += tDelta.z;
-        hitNormal = glm::ivec3(0, 0, -step.z);
-      }
-    } else {
-      if (tMax.y < tMax.z) {
-        voxel.y += step.y;
-        dist = tMax.y;
-        tMax.y += tDelta.y;
-        hitNormal = glm::ivec3(0, -step.y, 0);
-      } else {
-        voxel.z += step.z;
-        dist = tMax.z;
-        tMax.z += tDelta.z;
-        hitNormal = glm::ivec3(0, 0, -step.z);
-      }
+    int axis = 0;
+    if (tMax.y < tMax.x) axis = 1;
+    if (tMax.z < tMax[axis]) axis = 2;
+
+    if (tMax[axis] > maxDistance) {
+      break;
     }
+
+    voxel[axis] += step[axis];
+    dist = tMax[axis];
+    tMax[axis] += tDelta[axis];
+
+    hitNormal = glm::ivec3(0);
+    hitNormal[axis] = -step[axis];
   }
 
   return std::nullopt;

--- a/WorldRenderer.cpp
+++ b/WorldRenderer.cpp
@@ -18,15 +18,43 @@ void WorldRenderer::rebuildChunkMesh(Camera &cam, Chunk *chunk) {
     return;
   }
 
+  auto sameChunk = [&](const std::shared_ptr<ChunkObject>& obj) {
+    return obj && obj->chunk == chunk;
+  };
+
+  bool updatedExisting = false;
+  for (auto it = visibleChunks.begin(); it != visibleChunks.end(); ) {
+    if (sameChunk(*it)) {
+      if (!updatedExisting) {
+        auto& chunkObj = *it;
+        chunkObj->setChunk(chunk);
+        chunkObj->chunk_pos = {
+          chunk->position.x * CHUNK_SIZE,
+          chunk->position.y * CHUNK_SIZE,
+          chunk->position.z * CHUNK_SIZE
+        };
+        chunkObj->rebuildMesh(world);
+        updatedExisting = true;
+        ++it;
+      } else {
+        it = visibleChunks.erase(it);
+      }
+    } else {
+      ++it;
+    }
+  }
+
+  if (updatedExisting) {
+    return;
+  }
+
   auto chunkObj = std::make_shared<ChunkObject>(shader, texture_atlas);
   chunkObj->setChunk(chunk);
-
   chunkObj->chunk_pos = {
     chunk->position.x * CHUNK_SIZE,
     chunk->position.y * CHUNK_SIZE,
     chunk->position.z * CHUNK_SIZE
   };
-
   chunkObj->rebuildMesh(world);
   visibleChunks.push_back(std::move(chunkObj));
 }

--- a/main.cpp
+++ b/main.cpp
@@ -629,6 +629,49 @@ void place_block(BlockID block_id) {
     );
 }
 
+void move_player_with_collisions(const glm::vec3& offset) {
+    glm::vec3 movement = offset;
+
+    // Process each axis separately to resolve collisions.
+    for (int axis = 0; axis < 3; ++axis) {
+        float delta = movement[axis];
+        if (delta == 0.0f) continue;
+
+        player.position[axis] += delta;
+
+        AABB playerBox = player.getAABB();
+        auto nearbyBlocks = world.getNearbyBlocks(player.position);
+
+        for (auto& blockRef : nearbyBlocks) {
+            const Block& block = blockRef.get();
+            if (block.isAir()) continue;
+
+            AABB blockBox = block.getAABB();
+            if (!playerBox.intersects(blockBox)) continue;
+
+            if (delta > 0.0f) {
+                float penetration = playerBox.max[axis] - blockBox.min[axis];
+                player.position[axis] -= penetration;
+            } else {
+                float penetration = blockBox.max[axis] - playerBox.min[axis];
+                player.position[axis] += penetration;
+            }
+
+            if (axis == 1) {
+                player.gravity_velocity.y = 0.0f;
+                if (delta < 0.0f) {
+                    player.is_on_ground = true;
+                } else {
+                    player_jump_velocity.y = 0.0f;
+                }
+            }
+
+            // Update the player's AABB for subsequent collision checks on this axis.
+            playerBox = player.getAABB();
+        }
+    }
+}
+
 void game_logic() {
     ImGuiIO& io = ImGui::GetIO();
 
@@ -738,7 +781,7 @@ void game_logic() {
             camera.position += offset;
         }
         else {
-            player.position += offset;
+            move_player_with_collisions(offset);
         }
     }
     chunk_updater_tick(render_distance_radius);


### PR DESCRIPTION
## Summary
- stabilise the voxel ray cast by handling zero-length axes and tracking the stepped axis and hit normal safely
- add axis-separated collision resolution that keeps the player AABB out of solid blocks and updates gravity/jump state appropriately
- rebuild existing chunk meshes in place (initialising chunk pointers) so block removals refresh the visible geometry instead of duplicating meshes

## Testing
- cmake -S . -B build *(fails: missing glm package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfeecf34a4832d85f8b598c7d7a0e3